### PR TITLE
RETURNING clause in DeleteBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,13 @@ trace.log
 *.test
 godobin*
 vendor/
+
+# Vim temporary files
+*~
+
+# Vim swap files
+*.tmp
+*.swp
+*.swo
+*.swm
+*.swn

--- a/dat/delete.go
+++ b/dat/delete.go
@@ -9,6 +9,7 @@ type DeleteBuilder struct {
 	table          string
 	whereFragments []*whereFragment
 	isInterpolated bool
+	returnings     []string
 	scope          Scope
 	err            error
 }
@@ -57,6 +58,12 @@ func (b *DeleteBuilder) Where(whereSQLOrMap interface{}, args ...interface{}) *D
 	return b
 }
 
+// Returning sets the columns for the RETURNING clause
+func (b *DeleteBuilder) Returning(columns ...string) *DeleteBuilder {
+	b.returnings - columns
+	return b
+}
+
 // ToSQL serialized the DeleteBuilder to a SQL string
 // It returns the string with placeholders and a slice of query arguments
 func (b *DeleteBuilder) ToSQL() (string, []interface{}, error) {
@@ -90,6 +97,16 @@ func (b *DeleteBuilder) ToSQL() (string, []interface{}, error) {
 			return NewDatSQLErr(err)
 		}
 		writeScopeCondition(buf, whereFragment, &args, &placeholderStartPos)
+	}
+
+	// RETURNING clause
+	for i, c := range b.returnings {
+		if i == 0 {
+			buf.WriteString(" RETURNING ")
+		} else {
+			buf.WriteRune(',')
+		}
+		writeIdentifier(buf, c)
 	}
 
 	return buf.String(), args, nil

--- a/dat/delete.go
+++ b/dat/delete.go
@@ -60,7 +60,7 @@ func (b *DeleteBuilder) Where(whereSQLOrMap interface{}, args ...interface{}) *D
 
 // Returning sets the columns for the RETURNING clause
 func (b *DeleteBuilder) Returning(columns ...string) *DeleteBuilder {
-	b.returnings - columns
+	b.returnings = columns
 	return b
 }
 

--- a/dat/delete_test.go
+++ b/dat/delete_test.go
@@ -40,3 +40,11 @@ func TestDeleteWhereExprSql(t *testing.T) {
 	assert.Equal(t, sql, `DELETE FROM a WHERE (foo = $1) AND (id=$2)`)
 	assert.Exactly(t, args, []interface{}{"bar", 100})
 }
+
+func TestDeleteSQLReturning(t *testing.T) {
+	expr := Expr("id=$1", 100)
+	sql, args, err := DeleteFrom("a").Where("foo = $1", "bar").Where(expr).Returning("id", "foo").ToSQL()
+	assert.NoError(t, err)
+	assert.Equal(t, sql, `DELETE FROM a WHERE (foo = $1) AND (id=$2) RETURNING id,foo`)
+	assert.Equal(t, []interface{}{"bar", 100}, args)
+}


### PR DESCRIPTION
DeleteBuilder now has a Returning() method, similar to InsertBuilder and variants.

Also added some vim files to gitignore for convenience.