### PR TITLE
From clause support in UpdateBuilder

### DIFF
--- a/dat/update.go
+++ b/dat/update.go
@@ -12,6 +12,7 @@ type UpdateBuilder struct {
 	isInterpolated bool
 	table          string
 	setClauses     []*setClause
+	fromList       string
 	whereFragments []*whereFragment
 	orderBys       []string
 	limitCount     uint64
@@ -94,6 +95,13 @@ func (b *UpdateBuilder) SetWhitelist(rec interface{}, whitelist ...string) *Upda
 		b.Set(columns[i], val)
 	}
 
+	return b
+}
+
+// From sets the fromList to UPDATE FROM. JOINs may also be defined here.
+// Allows columns from other tables to appear in the WHERE condition and the update expressions.
+func (b *UpdateBuilder) From(from string) *UpdateBuilder {
+	b.fromList = from
 	return b
 }
 
@@ -194,6 +202,11 @@ func (b *UpdateBuilder) ToSQL() (string, []interface{}, error) {
 			placeholderStartPos++
 			args = append(args, c.value)
 		}
+	}
+
+	if len(b.fromList) > 0 {
+		buf.WriteString(" FROM ")
+		buf.WriteString(b.fromList)
 	}
 
 	if b.scope == nil {

--- a/dat/update_test.go
+++ b/dat/update_test.go
@@ -23,28 +23,28 @@ func BenchmarkUpdateValueMapSql(b *testing.B) {
 }
 
 func TestUpdateAllToSql(t *testing.T) {
-	sql, args, err := Update("a").Set("b", 1).Set("c", 2).ToSQL()
+	sql, args, err := Update("a").Set("b", 1).Set("c", 2).From("d").ToSQL()
 
 	assert.NoError(t, err)
-	assert.Equal(t, sql, quoteSQL(`UPDATE a SET %s = $1, %s = $2`, "b", "c"))
+	assert.Equal(t, sql, quoteSQL(`UPDATE a SET %s = $1, %s = $2 FROM d`, "b", "c"))
 	assert.Equal(t, args, []interface{}{1, 2})
 }
 
 func TestUpdateSingleToSql(t *testing.T) {
-	sql, args, err := Update("a").Set("b", 1).Set("c", 2).Where("id = $1", 1).ToSQL()
+	sql, args, err := Update("a").Set("b", 1).Set("c", 2).From("d").Where("id = $1", 1).ToSQL()
 	assert.NoError(t, err)
-	assert.Equal(t, sql, quoteSQL(`UPDATE a SET %s = $1, %s = $2 WHERE (id = $3)`, "b", "c"))
+	assert.Equal(t, sql, quoteSQL(`UPDATE a SET %s = $1, %s = $2 FROM d WHERE (id = $3)`, "b", "c"))
 	assert.Equal(t, args, []interface{}{1, 2, 1})
 }
 
 func TestUpdateSetMapToSql(t *testing.T) {
-	sql, args, err := Update("a").SetMap(map[string]interface{}{"b": 1, "c": 2}).Where("id = $1", 1).ToSQL()
+	sql, args, err := Update("a").SetMap(map[string]interface{}{"b": 1, "c": 2}).From("d").Where("id = $1", 1).ToSQL()
 	assert.NoError(t, err)
 
-	if sql == quoteSQL(`UPDATE a SET %s = $1, %s = $2 WHERE (id = $3)`, "b", "c") {
+	if sql == quoteSQL(`UPDATE a SET %s = $1, %s = $2 FROM d WHERE (id = $3)`, "b", "c") {
 		assert.Equal(t, args, []interface{}{1, 2, 1})
 	} else {
-		assert.Equal(t, sql, quoteSQL(`UPDATE a SET %s = $1, %s = $2 WHERE (id = $3)`, "c", "b"))
+		assert.Equal(t, sql, quoteSQL(`UPDATE a SET %s = $1, %s = $2 FROM d WHERE (id = $3)`, "c", "b"))
 		assert.Equal(t, args, []interface{}{2, 1, 1})
 	}
 }


### PR DESCRIPTION
Added ability to specify additional tables using the FROM clause. Allows you to modify a table using information contained in other tables.