### PR TITLE
Added ON CONFLICT clause in InsertBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ vendor/
 *.swo
 *.swm
 *.swn
+
+# Exuberant ctags
+tags

--- a/dat/insert.go
+++ b/dat/insert.go
@@ -24,7 +24,7 @@ type InsertBuilder struct {
 	err              error
 }
 
-// The ON CONFLICT target can be a column, constraint, or a WHERE clause predicate
+// The ON CONFLICT target can be a column or constraint
 type onConflictTargetType struct {
 	column     string
 	constraint string
@@ -49,10 +49,11 @@ type onConflictActionType struct {
 	whereFragments []*whereFragment
 }
 
-// Actions for ON CONFLICT
+// ON CONFLICT keywords
 const nothingAction = "NOTHING"
 const updateAction = "UPDATE"
 const excludedColumn = "EXCLUDED"
+const onConstraintPrefix = "ON CONSTRAINT "
 
 // NewInsertBuilder creates a new InsertBuilder for the given table.
 func NewInsertBuilder(table string) *InsertBuilder {
@@ -110,8 +111,6 @@ func (b *InsertBuilder) OnConflict(targets ...string) *InsertBuilder {
 		}
 		return b
 	}
-
-	const onConstraintPrefix = "ON CONSTRAINT "
 
 	target := targets[0]
 	if strings.HasPrefix(strings.ToUpper(target), onConstraintPrefix) {

--- a/dat/insert.go
+++ b/dat/insert.go
@@ -311,7 +311,7 @@ func (b *InsertBuilder) ToSQL() (string, []interface{}, error) {
 			placeholderStartPos := int64(start)
 			for i, c := range b.onConflictAction.setClauses {
 				if i > 0 {
-					sql.WriteRune(',')
+					sql.WriteString(", ")
 				}
 
 				writeIdentifier(&sql, c.column)

--- a/dat/insert_test.go
+++ b/dat/insert_test.go
@@ -163,7 +163,7 @@ func TestInsertOnConflictSetMultiple(t *testing.T) {
 }
 
 func TestInsertOnConflictSetExcluded(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", "EXCLUDED.b").ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").SetExcluded("b").ToSQL()
 
 	assert.NoError(t, err)
 
@@ -172,7 +172,16 @@ func TestInsertOnConflictSetExcluded(t *testing.T) {
 }
 
 func TestInsertOnConflictSetExcludedMultiple(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", "EXCLUDED.b").Set("c", "EXCLUDED.c").ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").SetExcluded("b, c").ToSQL()
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT (%s) DO UPDATE SET %s = %s, %s = %s", "b", "c", "b", "b", "EXCLUDED.b", "c", "EXCLUDED.c"), sql)
+	assert.Equal(t, []interface{}{1, 2}, args)
+}
+
+func TestInsertOnConflictSetExcludedMultipleTwo(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").SetExcluded("b", "c").ToSQL()
 
 	assert.NoError(t, err)
 
@@ -181,7 +190,7 @@ func TestInsertOnConflictSetExcludedMultiple(t *testing.T) {
 }
 
 func TestInsertOnConflictSetMultipleMixed(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", "EXCLUDED.b").Set("c", 50).ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").SetExcluded("b").Set("c", 50).ToSQL()
 
 	assert.NoError(t, err)
 
@@ -190,7 +199,7 @@ func TestInsertOnConflictSetMultipleMixed(t *testing.T) {
 }
 
 func TestInsertOnConflictSetMultipleMixedTwo(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", 50).Set("c", "EXCLUDED.c").ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", 50).SetExcluded("c").ToSQL()
 
 	assert.NoError(t, err)
 
@@ -208,7 +217,7 @@ func TestInsertOnConflictSetWhere(t *testing.T) {
 }
 
 func TestInsertOnConflictSetExcludedWhere(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", "EXCLUDED.b").Where("a.b = $1", 10).ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").SetExcluded("b").Where("a.b = $1", 10).ToSQL()
 
 	assert.NoError(t, err)
 

--- a/dat/insert_test.go
+++ b/dat/insert_test.go
@@ -121,7 +121,7 @@ func TestInsertDuplicateColumns(t *testing.T) {
 }
 
 func TestInsertOnConflictColumnDoNothing(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Do("NOTHING").ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").ToSQL()
 	assert.NoError(t, err)
 
 	assert.Equal(t, sql, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT (%s) DO NOTHING", "b", "c", "b"))
@@ -129,7 +129,7 @@ func TestInsertOnConflictColumnDoNothing(t *testing.T) {
 }
 
 func TestInsertOnConflictConstraintDoNothing(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictConstraint("test_constraint").Do("NOTHING").ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictConstraint("test_constraint").ToSQL()
 	assert.NoError(t, err)
 
 	assert.Equal(t, sql, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT ON CONSTRAINT test_constraint DO NOTHING", "b", "c"))
@@ -137,15 +137,15 @@ func TestInsertOnConflictConstraintDoNothing(t *testing.T) {
 }
 
 func TestInsertOnConflictWhereDoNothing(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictWhere("b", "b > 0").Do("NOTHING").ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictWhere("b", "b > 0").ToSQL()
 	assert.NoError(t, err)
 
 	assert.Equal(t, sql, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT (%s) WHERE %s DO NOTHING", "b", "c", "b", "b > 0"))
 	assert.Equal(t, args, []interface{}{1, 2})
 }
 
-func TestInsertOnConflictColumnDoUpdateSet(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Do("UPDATE").Set("b", 50).ToSQL()
+func TestInsertOnConflictSet(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", 50).ToSQL()
 
 	assert.NoError(t, err)
 
@@ -153,8 +153,8 @@ func TestInsertOnConflictColumnDoUpdateSet(t *testing.T) {
 	assert.Equal(t, []interface{}{1, 2, 50}, args)
 }
 
-func TestInsertOnConflictColumnDoUpdateMultiSet(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Do("UPDATE").Set("b", 50).Set("c", 100).ToSQL()
+func TestInsertOnConflictSetMultiple(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", 50).Set("c", 100).ToSQL()
 
 	assert.NoError(t, err)
 
@@ -162,17 +162,8 @@ func TestInsertOnConflictColumnDoUpdateMultiSet(t *testing.T) {
 	assert.Equal(t, []interface{}{1, 2, 50, 100}, args)
 }
 
-func TestInsertOnConflictConstraintDoUpdateSet(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictConstraint("test_constraint").Do("UPDATE").Set("b", 50).ToSQL()
-
-	assert.NoError(t, err)
-
-	assert.Equal(t, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT ON CONSTRAINT test_constraint DO UPDATE SET %s = $3", "b", "c", "b"), sql)
-	assert.Equal(t, []interface{}{1, 2, 50}, args)
-}
-
-func TestInsertOnConflictColumnDoUpdateSetExcluded(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Do("UPDATE").Set("b", "EXCLUDED.b").ToSQL()
+func TestInsertOnConflictSetExcluded(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", "EXCLUDED.b").ToSQL()
 
 	assert.NoError(t, err)
 
@@ -180,8 +171,8 @@ func TestInsertOnConflictColumnDoUpdateSetExcluded(t *testing.T) {
 	assert.Equal(t, []interface{}{1, 2}, args)
 }
 
-func TestInsertOnConflictColumnDoUpdateMultiSetExcluded(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Do("UPDATE").Set("b", "EXCLUDED.b").Set("c", "EXCLUDED.c").ToSQL()
+func TestInsertOnConflictSetExcludedMultiple(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", "EXCLUDED.b").Set("c", "EXCLUDED.c").ToSQL()
 
 	assert.NoError(t, err)
 
@@ -189,8 +180,8 @@ func TestInsertOnConflictColumnDoUpdateMultiSetExcluded(t *testing.T) {
 	assert.Equal(t, []interface{}{1, 2}, args)
 }
 
-func TestInsertOnConflictColumnDoUpdateMultiSetMixed(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Do("UPDATE").Set("b", "EXCLUDED.b").Set("c", 50).ToSQL()
+func TestInsertOnConflictSetMultipleMixed(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", "EXCLUDED.b").Set("c", 50).ToSQL()
 
 	assert.NoError(t, err)
 
@@ -198,8 +189,8 @@ func TestInsertOnConflictColumnDoUpdateMultiSetMixed(t *testing.T) {
 	assert.Equal(t, []interface{}{1, 2, 50}, args)
 }
 
-func TestInsertOnConflictColumnDoUpdateMultiSetMixedTwo(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Do("UPDATE").Set("b", 50).Set("c", "EXCLUDED.c").ToSQL()
+func TestInsertOnConflictSetMultipleMixedTwo(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", 50).Set("c", "EXCLUDED.c").ToSQL()
 
 	assert.NoError(t, err)
 
@@ -207,17 +198,8 @@ func TestInsertOnConflictColumnDoUpdateMultiSetMixedTwo(t *testing.T) {
 	assert.Equal(t, []interface{}{1, 2, 50}, args)
 }
 
-func TestInsertOnConflictConstraintDoUpdateSetExcluded(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictConstraint("test_constraint").Do("UPDATE").Set("b", "EXCLUDED.b").ToSQL()
-
-	assert.NoError(t, err)
-
-	assert.Equal(t, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT ON CONSTRAINT test_constraint DO UPDATE SET %s = %s", "b", "c", "b", "EXCLUDED.b"), sql)
-	assert.Equal(t, []interface{}{1, 2}, args)
-}
-
-func TestInsertOnConflictColumnDoUpdateSetWhere(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Do("UPDATE").Set("b", 50).Where("a.b = $1", 10).ToSQL()
+func TestInsertOnConflictSetWhere(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", 50).Where("a.b = $1", 10).ToSQL()
 
 	assert.NoError(t, err)
 
@@ -225,29 +207,11 @@ func TestInsertOnConflictColumnDoUpdateSetWhere(t *testing.T) {
 	assert.Equal(t, []interface{}{1, 2, 50, 10}, args)
 }
 
-func TestInsertOnConflictConstraintDoUpdateSetWhere(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictConstraint("test_constraint").Do("UPDATE").Set("b", 50).Where("a.b = $1", 10).ToSQL()
-
-	assert.NoError(t, err)
-
-	assert.Equal(t, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT ON CONSTRAINT test_constraint DO UPDATE SET %s = $3 WHERE (%s = $4)", "b", "c", "b", "a.b"), sql)
-	assert.Equal(t, []interface{}{1, 2, 50, 10}, args)
-}
-
-func TestInsertOnConflictColumnDoUpdateSetExcludedWhere(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Do("UPDATE").Set("b", "EXCLUDED.b").Where("a.b = $1", 10).ToSQL()
+func TestInsertOnConflictSetExcludedWhere(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", "EXCLUDED.b").Where("a.b = $1", 10).ToSQL()
 
 	assert.NoError(t, err)
 
 	assert.Equal(t, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT (%s) DO UPDATE SET %s = %s WHERE (%s = $3)", "b", "c", "b", "b", "EXCLUDED.b", "a.b"), sql)
-	assert.Equal(t, []interface{}{1, 2, 10}, args)
-}
-
-func TestInsertOnConflictConstraintDoUpdateSetExcludedWhere(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictConstraint("test_constraint").Do("UPDATE").Set("b", "EXCLUDED.b").Where("a.b = $1", 10).ToSQL()
-
-	assert.NoError(t, err)
-
-	assert.Equal(t, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT ON CONSTRAINT test_constraint DO UPDATE SET %s = %s WHERE (%s = $3)", "b", "c", "b", "EXCLUDED.b", "a.b"), sql)
 	assert.Equal(t, []interface{}{1, 2, 10}, args)
 }

--- a/dat/insert_test.go
+++ b/dat/insert_test.go
@@ -179,6 +179,24 @@ func TestInsertOnConflictSetExcluded(t *testing.T) {
 	assert.Equal(t, []interface{}{1, 2}, args)
 }
 
+func TestInsertOnConflictSetExcludedTwo(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").Set("b", EXCLUDED).ToSQL()
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT (%s) DO UPDATE SET %s = %s", "b", "c", "b", "b", "EXCLUDED.b"), sql)
+	assert.Equal(t, []interface{}{1, 2}, args)
+}
+
+func TestInsertOnConflictSetUnsafe(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").Set("b", UnsafeString("foo.bar")).ToSQL()
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT (%s) DO UPDATE SET %s = %s", "b", "c", "b", "b", "foo.bar"), sql)
+	assert.Equal(t, []interface{}{1, 2}, args)
+}
+
 func TestInsertOnConflictSetExcludedMultiple(t *testing.T) {
 	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").SetExcluded("b, c").ToSQL()
 

--- a/dat/insert_test.go
+++ b/dat/insert_test.go
@@ -120,11 +120,19 @@ func TestInsertDuplicateColumns(t *testing.T) {
 	assert.Equal(t, args, []interface{}{"open"})
 }
 
-func TestInsertOnConflictColumnDoNothing(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").ToSQL()
+func TestInsertOnConflictColumnsDoNothing(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").ToSQL()
 	assert.NoError(t, err)
 
 	assert.Equal(t, sql, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT (%s) DO NOTHING", "b", "c", "b"))
+	assert.Equal(t, args, []interface{}{1, 2})
+}
+
+func TestInsertOnConflictColumnsMultipleDoNothing(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b", "c").ToSQL()
+	assert.NoError(t, err)
+
+	assert.Equal(t, sql, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT (%s, %s) DO NOTHING", "b", "c", "b", "c"))
 	assert.Equal(t, args, []interface{}{1, 2})
 }
 
@@ -137,7 +145,7 @@ func TestInsertOnConflictConstraintDoNothing(t *testing.T) {
 }
 
 func TestInsertOnConflictWhereDoNothing(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictWhere("b", "b > 0").ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictWhere("b > 0", "b").ToSQL()
 	assert.NoError(t, err)
 
 	assert.Equal(t, sql, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT (%s) WHERE %s DO NOTHING", "b", "c", "b", "b > 0"))
@@ -145,7 +153,7 @@ func TestInsertOnConflictWhereDoNothing(t *testing.T) {
 }
 
 func TestInsertOnConflictSet(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", 50).ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").Set("b", 50).ToSQL()
 
 	assert.NoError(t, err)
 
@@ -154,7 +162,7 @@ func TestInsertOnConflictSet(t *testing.T) {
 }
 
 func TestInsertOnConflictSetMultiple(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", 50).Set("c", 100).ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").Set("b", 50).Set("c", 100).ToSQL()
 
 	assert.NoError(t, err)
 
@@ -163,7 +171,7 @@ func TestInsertOnConflictSetMultiple(t *testing.T) {
 }
 
 func TestInsertOnConflictSetExcluded(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").SetExcluded("b").ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").SetExcluded("b").ToSQL()
 
 	assert.NoError(t, err)
 
@@ -172,7 +180,7 @@ func TestInsertOnConflictSetExcluded(t *testing.T) {
 }
 
 func TestInsertOnConflictSetExcludedMultiple(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").SetExcluded("b, c").ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").SetExcluded("b, c").ToSQL()
 
 	assert.NoError(t, err)
 
@@ -181,7 +189,7 @@ func TestInsertOnConflictSetExcludedMultiple(t *testing.T) {
 }
 
 func TestInsertOnConflictSetExcludedMultipleTwo(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").SetExcluded("b", "c").ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").SetExcluded("b", "c").ToSQL()
 
 	assert.NoError(t, err)
 
@@ -190,7 +198,7 @@ func TestInsertOnConflictSetExcludedMultipleTwo(t *testing.T) {
 }
 
 func TestInsertOnConflictSetMultipleMixed(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").SetExcluded("b").Set("c", 50).ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").SetExcluded("b").Set("c", 50).ToSQL()
 
 	assert.NoError(t, err)
 
@@ -199,7 +207,7 @@ func TestInsertOnConflictSetMultipleMixed(t *testing.T) {
 }
 
 func TestInsertOnConflictSetMultipleMixedTwo(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", 50).SetExcluded("c").ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").Set("b", 50).SetExcluded("c").ToSQL()
 
 	assert.NoError(t, err)
 
@@ -208,7 +216,7 @@ func TestInsertOnConflictSetMultipleMixedTwo(t *testing.T) {
 }
 
 func TestInsertOnConflictSetWhere(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Set("b", 50).Where("a.b = $1", 10).ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").Set("b", 50).Where("a.b = $1", 10).ToSQL()
 
 	assert.NoError(t, err)
 
@@ -217,7 +225,7 @@ func TestInsertOnConflictSetWhere(t *testing.T) {
 }
 
 func TestInsertOnConflictSetExcludedWhere(t *testing.T) {
-	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").SetExcluded("b").Where("a.b = $1", 10).ToSQL()
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b").SetExcluded("b").Where("a.b = $1", 10).ToSQL()
 
 	assert.NoError(t, err)
 

--- a/dat/insert_test.go
+++ b/dat/insert_test.go
@@ -136,6 +136,14 @@ func TestInsertOnConflictConstraintDoNothing(t *testing.T) {
 	assert.Equal(t, args, []interface{}{1, 2})
 }
 
+func TestInsertOnConflictWhereDoNothing(t *testing.T) {
+	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictWhere("b", "b > 0").Do("NOTHING").ToSQL()
+	assert.NoError(t, err)
+
+	assert.Equal(t, sql, quoteSQL("INSERT INTO a (%s,%s) VALUES ($1,$2) ON CONFLICT (%s) WHERE %s DO NOTHING", "b", "c", "b", "b > 0"))
+	assert.Equal(t, args, []interface{}{1, 2})
+}
+
 func TestInsertOnConflictColumnDoUpdateSet(t *testing.T) {
 	sql, args, err := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumn("b").Do("UPDATE").Set("b", 50).ToSQL()
 

--- a/dat/types.go
+++ b/dat/types.go
@@ -33,6 +33,9 @@ func (u UnsafeString) Value() (driver.Value, error) {
 // DEFAULT SQL value
 const DEFAULT = UnsafeString("DEFAULT")
 
+// EXCLUDED SQL value in reference to special table for ON CONFLICT
+const EXCLUDED = UnsafeString("EXCLUDED.")
+
 // NOW SQL value
 const NOW = UnsafeString("NOW()")
 

--- a/dat/types.go
+++ b/dat/types.go
@@ -69,9 +69,19 @@ func NullStringFrom(v string) NullString {
 	return NullString{sql.NullString{String: v, Valid: true}}
 }
 
+// NullIfString creates a NullString invalid on equivalency
+func NullIfString(v1 string, v2 string) NullString {
+	return NullString{sql.NullString{String: v1, Valid: v1 != v2}}
+}
+
 // NullFloat64From creates a valid NullFloat64
 func NullFloat64From(v float64) NullFloat64 {
 	return NullFloat64{sql.NullFloat64{Float64: v, Valid: true}}
+}
+
+// NullIfFloat64 creates a NullFloat64 invalid on equivalency
+func NullIfFloat64(v1 float64, v2 float64) NullFloat64 {
+	return NullFloat64{sql.NullFloat64{Float64: v1, Valid: v1 != v2}}
 }
 
 // NullInt64From creates a valid NullInt64
@@ -79,14 +89,29 @@ func NullInt64From(v int64) NullInt64 {
 	return NullInt64{sql.NullInt64{Int64: v, Valid: true}}
 }
 
+// NullIfInt64 creates a NullInt64 invalid on equivalency
+func NullIfInt64(v1 int64, v2 int64) NullInt64 {
+	return NullInt64{sql.NullInt64{Int64: v1, Valid: v1 != v2}}
+}
+
 // NullTimeFrom creates a valid NullTime
 func NullTimeFrom(v time.Time) NullTime {
 	return NullTime{pq.NullTime{Time: v, Valid: true}}
 }
 
+// NullIfTime creates a NullTime invalid on equivalency
+func NullIfTime(v1 time.Time, v2 time.Time) NullTime {
+	return NullTime{pq.NullTime{Time: v1, Valid: !v1.Equal(v2)}}
+}
+
 // NullBoolFrom creates a valid NullBool
 func NullBoolFrom(v bool) NullBool {
 	return NullBool{sql.NullBool{Bool: v, Valid: true}}
+}
+
+// NullIfBool creates a NullBool invalid on equivalency
+func NullIfBool(v1 bool, v2 bool) NullBool {
+	return NullBool{sql.NullBool{Bool: v1, Valid: v1 != v2}}
 }
 
 // JSONFromString creates a JSON type from JSON encoded string.

--- a/dat/types_test.go
+++ b/dat/types_test.go
@@ -18,12 +18,34 @@ func TestNullStringFrom(t *testing.T) {
 	assert.Equal(t, n.String, v)
 }
 
+func TestNullIfString(t *testing.T) {
+	v := "foo"
+	n := NullIfString(v, "")
+	m := NullIfString(v, v)
+
+	assert.True(t, n.Valid)
+	assert.Equal(t, n.String, v)
+	assert.False(t, m.Valid)
+	assert.Equal(t, m.String, v)
+}
+
 func TestNullFloat64From(t *testing.T) {
 	v := 42.2
 	n := NullFloat64From(v)
 
 	assert.True(t, n.Valid)
 	assert.Equal(t, n.Float64, v)
+}
+
+func TestNullIfFloat64(t *testing.T) {
+	v := 42.2
+	n := NullIfFloat64(v, 0.0)
+	m := NullIfFloat64(v, v)
+
+	assert.True(t, n.Valid)
+	assert.Equal(t, n.Float64, v)
+	assert.False(t, m.Valid)
+	assert.Equal(t, m.Float64, v)
 }
 
 func TestNullInt64From(t *testing.T) {
@@ -34,6 +56,17 @@ func TestNullInt64From(t *testing.T) {
 	assert.Equal(t, n.Int64, v)
 }
 
+func TestNullIfInt64(t *testing.T) {
+	v := int64(400)
+	n := NullIfInt64(v, 0)
+	m := NullIfInt64(v, v)
+
+	assert.True(t, n.Valid)
+	assert.Equal(t, n.Int64, v)
+	assert.False(t, m.Valid)
+	assert.Equal(t, m.Int64, v)
+}
+
 func TestNullTimeFrom(t *testing.T) {
 	v := time.Now()
 	n := NullTimeFrom(v)
@@ -42,12 +75,35 @@ func TestNullTimeFrom(t *testing.T) {
 	assert.Equal(t, n.Time, v)
 }
 
+func TestNullIfTime(t *testing.T) {
+	v := time.Now()
+	var when time.Time
+	n := NullIfTime(v, when)
+	m := NullIfTime(v, v)
+
+	assert.True(t, n.Valid)
+	assert.Equal(t, n.Time, v)
+	assert.False(t, m.Valid)
+	assert.Equal(t, m.Time, v)
+}
+
 func TestNullBoolFrom(t *testing.T) {
 	v := false
 	n := NullBoolFrom(v)
 
 	assert.True(t, n.Valid)
 	assert.Equal(t, n.Bool, v)
+}
+
+func TestNullIfBool(t *testing.T) {
+	v := false
+	n := NullIfBool(v, true)
+	m := NullIfBool(v, v)
+
+	assert.True(t, n.Valid)
+	assert.Equal(t, n.Bool, v)
+	assert.False(t, m.Valid)
+	assert.Equal(t, m.Bool, v)
 }
 
 func TestInvalidNullTime(t *testing.T) {


### PR DESCRIPTION
Supports the ON CONFLICT clause used for upserting as an extension to an INSERT.

Example  usage:
```go
q := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b", "c").SetExcluded("b", "c")
```

Or the equivalent statement

```go
q := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b", "c").Set("b", dat.EXCLUDED).Set("c", dat.EXCLUDED)
```

Or with a constraint as the conflict_target instead of columns:
```go
q := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictConstraint("unique_b_a").SetExcluded("b", "c")
```

On a partial index:
```go
q := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictWhere("b > 0", "b", "c").SetExcluded("b", "c")
```

With SETs not from the special excluded table:
```go
q := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b", "c").Set("b", dat.UnsafeString("foo.bar")).Set("c", 100)
```

With a WHERE clause:
```go
q := InsertInto("a").Columns("b", "c").Values(1, 2).OnConflictColumns("b", "c").SetExcluded("b", "c").Where("a.b = $1", 10)
```

et cetera. See `insert_test.go` for further usage patterns.